### PR TITLE
PlotNumbers + PlotLabels -- propagate 'main' argument to plot.igraph

### DIFF
--- a/R/3_buildMST.R
+++ b/R/3_buildMST.R
@@ -626,10 +626,11 @@ PlotNumbers <- function(fsom, view="MST",main=NULL,nodeSize=fsom$MST$size,
         vertex.label=seq_len(nrow(fsom$map$codes)),
         vertex.label.cex = fontSize,
         edge.lty=lty,
-        mark.groups=background$groups, 
-        mark.col=background$col[background$values], 
-        mark.border=background$col[background$values])
-    
+        mark.groups=background$groups,
+        mark.col=background$col[background$values],
+        mark.border=background$col[background$values],
+        main=main)
+
 }
 
 #' Plot a label in each node

--- a/R/3_buildMST.R
+++ b/R/3_buildMST.R
@@ -713,10 +713,11 @@ PlotLabels <- function(fsom,
                       vertex.label=labels,
                       vertex.label.cex = fontSize,
                       edge.lty=lty,
-                      mark.groups=background$groups, 
-                      mark.col=background$col[background$values], 
-                      mark.border=background$col[background$values])
-  
+                      mark.groups=background$groups,
+                      mark.col=background$col[background$values],
+                      mark.border=background$col[background$values],
+                      main=main)
+
 }
 
 ##############


### PR DESCRIPTION
* `PlotNumbers` accepts a 'main' argument, like `PlotPies` does, but unlike
  `PlotPies`, it does not propagate the value to the call to `plot.igraph`,
  so the argument effectively did nothing and there was no way to add
  a title to a plot produced by `PlotNumbers`.
* With this change it should be propagated through and now `PlotNumbers`
  plots can have titles
* Also did the same for `PlotLabels`