### PR TITLE
Fix creating scaled.scale and scaled.center

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: FlowSOM
-Version: 1.15.3
+Version: 1.15.4
 Date: 2019-01-18
 Title: Using self-organizing maps for visualization and interpretation
     of cytometry data

--- a/R/1_readInput.R
+++ b/R/1_readInput.R
@@ -122,21 +122,21 @@ ReadInput <- function(input, pattern=".fcs",
         if(!silent) message("Scaling the data\n")
         if(!all(is.null(names(scaled.center)))){
           cols_to_scale <- intersect(colnames(fsom$data), names(scaled.center))
-          fsom$data[, cols_to_scale] <- scale(x = fsom$data[, cols_to_scale], 
-                                              center = scaled.center[cols_to_scale], 
-                                              scale = scaled.scale[cols_to_scale])
+          sc <- scale(x = fsom$data[, cols_to_scale], 
+                      center = scaled.center[cols_to_scale], 
+                      scale = scaled.scale[cols_to_scale])
+          fsom$data[, cols_to_scale] <- sc
+          fsom$scaled.center <- attr(sc, "scaled:center")
+          fsom$scaled.scale <- attr(sc, "scaled:scale")
         } else {
-          cols_to_scale <- colnames(fsom$data)
-          fsom$data[, cols_to_scale] <- scale(x = fsom$data[, cols_to_scale], 
-                                              center = TRUE, 
-                                              scale = TRUE)
+          fsom$data <- scale(x = fsom$data, center = TRUE, scale = TRUE)
+
+          fsom$scaled.center <- attr(fsom$data, "scaled:center")
+          attr(fsom$data, "scaled:center") <- NULL
+          fsom$scaled.scale <- attr(fsom$data, "scaled:scale") 
+          attr(fsom$data, "scaled:scale") <- NULL
         }
 
-        
-        fsom$scaled.center <- attr(fsom$data, "scaled:center")
-        attr(fsom$data, "scaled:center") <- NULL
-        fsom$scaled.scale <- attr(fsom$data, "scaled:scale") 
-        attr(fsom$data, "scaled:scale") <- NULL
     }
     
     fsom


### PR DESCRIPTION
Hello Sofie!

We've recently noticed that FlowSOM version 1.15.3 no longer creates the `fsom$scaled.scale` and `fsom$scaled.center` objects, which we used for several purposes (more precisely-- Abhishek ran into the issue around an hour ago while preparing some new poster). Quick search in the commit history showed that these might have been removed inadvertenly; this commit fixes that.

The other new case (when only a few of the columns is scaled) is handled as well; the code just puts identity scale/centering values into the `scaled.*` of columns that do not get scaled. I hope it works right with the rest of the workflow. The other possibility is to leave the scaling vectors sparse; let me know if I should change the commit that way.

If the `scaled.scale` and `scaled.center` removal was intentional, please let me know, I'd remove the dependency on that from the rest of our code.

For compatibility reasons I also increased the FlowSOM version by 0.0.1 in the same commit (so that packages may depend on this by using >=1.15.4 dep), but that is only cosmetic and not really required; feel free to discard that change.

Thank you in advance,

with best regards,
-mk

(attached commit message follows)

```
R attr()s do not get preserved when assigning data into a sub-range of a larger
frame (even if the range is just "whole data"); for that reason attr(fsom$data,
"scaled:scale") is not created after a recent update of scale handing. This
attempts to reconstruct a reasonable scaled.scale/scaled.center in both new
cases.
```